### PR TITLE
Resolve #8 and #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **06.04.24:** - Fix deprecated `sync` command
+* **06.04.24:** - Fix deprecated `sync` command & add support for disabling `watch` command
 * **16.05.23:** - Rebase to alpine 3.18, deprecate arm32v7 (armhf) per [this notice](https://info.linuxserver.io/issues/2023-05-06-armhf/).
 * **24.07.22:** - Check for `config.yml` instead of the deprecated `config.json`.
 * **30.03.22:** - Initial Release.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **06.04.24:** - Fix deprecated `sync` command
 * **16.05.23:** - Rebase to alpine 3.18, deprecate arm32v7 (armhf) per [this notice](https://info.linuxserver.io/issues/2023-05-06-armhf/).
 * **24.07.22:** - Check for `config.yml` instead of the deprecated `config.json`.
 * **30.03.22:** - Initial Release.

--- a/root/defaults/abc
+++ b/root/defaults/abc
@@ -1,2 +1,2 @@
 # min   hour    day     month   weekday command
-0 */2 * * * /usr/bin/with-contenv python3 -m plextraktsync
+0 */2 * * * /usr/bin/with-contenv python3 -m plextraktsync sync

--- a/root/etc/s6-overlay/s6-rc.d/svc-plextraktsync/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-plextraktsync/run
@@ -1,8 +1,14 @@
 #!/usr/bin/with-contenv bash
 
 if [ -f /config/.env ] && [ -f /config/.pytrakt.json ]; then
-    exec \
-        s6-setuidgid abc python3 -m plextraktsync watch
+    if [ -f /config/NO_WATCH ]; then
+        echo "'plextraktsync watch' is disabled because of 'NO_WATCH' file"
+        exec \
+            sleep infinity
+    else
+        exec \
+            s6-setuidgid abc python3 -m plextraktsync watch
+    fi
 else
     echo "**** Plex and/or Trakt.tv account info missing. Please manually run an initial sync via the following command on your docker host and restart the container when finished: ****"
     echo "docker exec -it plextraktsync plextraktsync sync"

--- a/root/etc/s6-overlay/s6-rc.d/svc-plextraktsync/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-plextraktsync/run
@@ -5,7 +5,7 @@ if [ -f /config/.env ] && [ -f /config/.pytrakt.json ]; then
         s6-setuidgid abc python3 -m plextraktsync watch
 else
     echo "**** Plex and/or Trakt.tv account info missing. Please manually run an initial sync via the following command on your docker host and restart the container when finished: ****"
-    echo "docker exec -it plextraktsync plextraktsync"
+    echo "docker exec -it plextraktsync plextraktsync sync"
     exec \
         sleep infinity
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/lsio-labs-wide.png)](https://linuxserver.io)

<!--- Before submitting a pull request please check the following -->

<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->

<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ ] I have read the [contributing](https://github.com/linuxserver-labs/docker-plextraktsync/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

^ This file doesn't exist. - Also, there is no `readme-vars.yml`, so I made my changes directly in the README

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
This fixes the deprecated `sync` (#8) and adds an option to disable the `watch` command (#9).

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Even though the `watch` command is the main goal of this repo, there is now an option to opt-out (#9).
Also, the deprecated command is migrated (#8).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Tested directly

Tested it with directly modifying the container and killing the original service:
![image](https://github.com/linuxserver-labs/docker-plextraktsync/assets/6838669/8d977aed-5f58-4bfc-86c9-5e9483128545)
_(Screenshot taken at 10:32, for timestamp references.)_

### Tested with own image

Tested _before_ with image `rala72/plextraktsync-test` _(on the screenshot, the `sleep infinity is missing`)_:
![image](https://github.com/linuxserver-labs/docker-plextraktsync/assets/6838669/3062445c-3035-43df-a01b-cd50c8d01e18)

> if I run it manually it works, but I don't really get the two logs above - seems like a normal dockerfile build is building the image in a different way or so?
also, the first line is from a different folder which I haven't touched; not sure about the second line
and I haven't found my echo in the container startup protocol 🤔 

### Conclusion

both test show the expected log line, if I create a `NO_WATCH` file

are these tests sufficient?
otherwise, does someone have an idea why simply running the docker file results in this bash error or how to fix it?

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
Issues: #8, #9
https://discord.com/channels/354974912613449730/1226189951490854932/1226189951490854932