### PR TITLE
Add sync command, fix for deprecation of running without a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **27.07.24:** - Add ̀`sync` command to `plextraktsync` in cron file per deprecation warning of running without a command.
+* **07.05.25:** - Add ̀`sync` command to `plextraktsync` in cron file per deprecation warning of running without a command.
 * **28.05.24:** - Rebase to alpine 3.20.
 * **16.05.23:** - Rebase to alpine 3.18, deprecate arm32v7 (armhf) per [this notice](https://info.linuxserver.io/issues/2023-05-06-armhf/).
 * **24.07.22:** - Check for `config.yml` instead of the deprecated `config.json`.

--- a/root/defaults/abc
+++ b/root/defaults/abc
@@ -1,2 +1,2 @@
 # min   hour    day     month   weekday command
-0 */2 * * * /usr/bin/with-contenv python3 -m plextraktsync
+0 */2 * * * /usr/bin/with-contenv python3 -m plextraktsync sync


### PR DESCRIPTION

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/lsio-labs-wide.png)](https://linuxserver.io)

- [x] I have read the [contributing](https://github.com/linuxserver-labs/docker-plextraktsync/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Running Plextraktsync without a command is deprecated conform a warning message shown at running without a command.

closes #8 

## Benefits of this PR and context:
At the moment `plextraktsync` still executes the sync command and gives a warning about the deprecation, but in the future they could change this behavior which will break the functionality of this container.

## How Has This Been Tested?
tested by running the container and read the log which showed no deprecation warning anymore.

